### PR TITLE
🛡️ Error boundary global (error.vue) + robustesse UX des toasts

### DIFF
--- a/app/components/auth/AuthModal.vue
+++ b/app/components/auth/AuthModal.vue
@@ -70,7 +70,7 @@ import { useToast } from '~/composables/useToast'
 import { useRoute } from 'vue-router'
 
 const uiStore = useUiStore()
-const { success: showSuccessToast, denied: showErrorToast } = useToast()
+const { success: showSuccessToast, error: showErrorToast } = useToast()
 const route = useRoute()
 
 const handleSuccess = () => {

--- a/app/components/base/BaseToast.vue
+++ b/app/components/base/BaseToast.vue
@@ -11,7 +11,8 @@
     :class="{
       'bg-green-500 text-white': toast.type === 'success',
       'bg-red-500 text-white': toast.type === 'error',
-      'bg-blue-500 text-white': toast.type === 'info'
+      'bg-blue-500 text-white': toast.type === 'info',
+      'bg-yellow-500 text-white': toast.type === 'warning'
     }"
   >
     <component

--- a/app/components/base/LikeButton.vue
+++ b/app/components/base/LikeButton.vue
@@ -46,7 +46,7 @@ const props = withDefaults(defineProps<{
 
 const user = useSupabaseUser()
 const uiStore = useUiStore()
-const { success, denied } = useToast()
+const { success, error: showErrorToast } = useToast()
 
 // États
 const isLoading = ref(false)
@@ -118,7 +118,7 @@ const toggleLike = async () => {
     likesCount.value = previousCount
       
     console.error('Error toggling like:', error)
-    denied(error.data?.message || 'Erreur lors du like')
+    showErrorToast(error.data?.message || 'Erreur lors du like')
   } finally {
     isLoading.value = false
   }

--- a/app/components/gifs/FileUpload.vue
+++ b/app/components/gifs/FileUpload.vue
@@ -58,7 +58,7 @@ const emit = defineEmits<{
 const file = ref<File | null>(null);
 const previewUrl = ref<string | null>(null);
 const isDragging = ref(false);
-const { denied } = useToast();
+const { error: showErrorToast } = useToast();
 
 const onFileChange = (event: Event) => {
   const input = event.target as HTMLInputElement;
@@ -78,7 +78,7 @@ const handleFile = (selectedFile: File) => {
   if (!selectedFile) return;
   
   if (selectedFile.type !== 'image/gif') {
-    denied('Veuillez sélectionner un fichier GIF valide.');
+    showErrorToast('Veuillez sélectionner un fichier GIF valide.');
     return;
   }
 

--- a/app/components/gifs/ShareButtons.vue
+++ b/app/components/gifs/ShareButtons.vue
@@ -7,7 +7,7 @@ const props = defineProps<{
   quote: string
 }>()
 
-const { success, denied } = useToast()
+const { success, error: showErrorToast } = useToast()
 const currentUrl = ref('')
 const isLinkCopied = ref(false)
 
@@ -36,7 +36,7 @@ const copyLink = async () => {
       isLinkCopied.value = false
     }, 2000)
   } catch (err) {
-    denied('Erreur lors de la copie du lien')
+    showErrorToast('Erreur lors de la copie du lien')
   }
 }
 </script>

--- a/app/components/gifs/UploadForm.vue
+++ b/app/components/gifs/UploadForm.vue
@@ -93,7 +93,7 @@ const props = withDefaults(defineProps<Props>(), {
 
 const isLoading = ref(false);
 const file = ref<File | null>(null);
-const { success, denied } = useToast();
+const { success, error: showErrorToast } = useToast();
 
 const characters = props.characters;
 const episodes = props.episodes ?? [];
@@ -146,7 +146,7 @@ const handleFileCleared = () => {
 const uploadFile = async () => {
   isLoading.value = true;
   if (!file.value || !isFormValid.value) {
-    denied('Veuillez remplir tous les champs requis.');
+    showErrorToast('Veuillez remplir tous les champs requis.');
     isLoading.value = false;
     return;
   }
@@ -188,11 +188,11 @@ const uploadFile = async () => {
       navigateTo(`/gifs/${slug}`)
       emit('upload-success');
     } else {
-      denied('Erreur lors du téléchargement.');
+      showErrorToast('Erreur lors du téléchargement.');
     }
   } catch (error) {
     console.error(error, 'error');
-    denied('Erreur lors du téléchargement.');
+    showErrorToast('Erreur lors du téléchargement.');
   } finally {
     isLoading.value = false;
   }

--- a/app/composables/useCommentForm.ts
+++ b/app/composables/useCommentForm.ts
@@ -21,7 +21,7 @@ interface UseCommentFormOptions {
  * @returns {Object} Un objet contenant l'état et les méthodes de gestion du formulaire
  */
 export const useCommentForm = (options: UseCommentFormOptions = {}) => {
-  const { success, denied } = useToast()
+  const { success, error: showErrorToast } = useToast()
 
   // États
   const content = ref(options.initialContent || '')
@@ -79,7 +79,7 @@ export const useCommentForm = (options: UseCommentFormOptions = {}) => {
       options.onSuccess?.()
     } catch (error) {
       console.error('Erreur lors de la soumission du commentaire:', error)
-      denied(options.commentId 
+      showErrorToast(options.commentId
         ? 'Impossible de modifier le commentaire'
         : 'Impossible de publier le commentaire'
       )

--- a/app/composables/useCommentsList.ts
+++ b/app/composables/useCommentsList.ts
@@ -20,7 +20,7 @@ interface UseCommentsListOptions {
  * @property {Function} loadComments - Fonction pour charger les commentaires
  */
 export const useCommentsList = (options: UseCommentsListOptions) => {
-  const { success, denied } = useToast()
+  const { success, error: showErrorToast } = useToast()
 
   // États
   const comments = ref<CommentWithUser[]>([])
@@ -44,7 +44,7 @@ export const useCommentsList = (options: UseCommentsListOptions) => {
       comments.value = data.value || []
     } catch (error) {
       console.error('Erreur lors du chargement des commentaires:', error)
-      denied('Impossible de charger les commentaires')
+      showErrorToast('Impossible de charger les commentaires')
     } finally {
       isLoading.value = false
     }
@@ -81,7 +81,7 @@ export const useCommentsList = (options: UseCommentsListOptions) => {
       success('Commentaire publié avec succès')
     } catch (error) {
       console.error('Erreur lors de la publication du commentaire:', error)
-      denied('Impossible de publier le commentaire')
+      showErrorToast('Impossible de publier le commentaire')
     } finally {
       isSubmitting.value = false
     }

--- a/app/composables/useLikesList.ts
+++ b/app/composables/useLikesList.ts
@@ -42,32 +42,31 @@ export const useLikesList = (options: UseLikesListOptions = {}) => {
   // États
   const currentPage = ref(Number(route.query.page) || 1)
   const selectedType = ref<LikeableEntity | undefined>(route.query.type as LikeableEntity || options.entityType)
-  const isLoading = ref(false)
-  const error = ref<Error | null>(null)
 
-  // Requête pour récupérer les likes
-  const { data, refresh } = useFetch<LikesListResponse>('/api/likes', {
+  // Requête pour récupérer les likes.
+  // On s'appuie sur l'état natif de useFetch (`status`, `error`) plutôt que
+  // sur des refs maintenues manuellement via les callbacks, plus fiables lors
+  // des refetch successifs.
+  const { data, status, error: fetchError, refresh } = useFetch<LikesListResponse>('/api/likes', {
     query: computed(() => ({
       type: selectedType.value,
       page: currentPage.value,
       itemsPerPage: options.itemsPerPage || 21
-    })),
-    onRequest() {
-      isLoading.value = true
-      error.value = null
-    },
-    onResponse() {
-      isLoading.value = false
-    },
-    onResponseError({ response }) {
-      isLoading.value = false
-      error.value = new Error(response._data?.message || 'Erreur lors de la récupération des favoris')
-    }
+    }))
   })
 
   // Computed properties
   const likes = computed(() => data.value?.likes || [])
   const totalPages = computed(() => data.value?.totalPages || 0)
+  const isLoading = computed(() => status.value === 'pending')
+  const error = computed(() =>
+    fetchError.value
+      ? new Error(
+        (fetchError.value.data as { message?: string })?.message
+        || 'Erreur lors de la récupération des favoris'
+      )
+      : null
+  )
 
   // Méthodes
   const setPage = (page: number) => {

--- a/app/composables/useToast.test.ts
+++ b/app/composables/useToast.test.ts
@@ -19,8 +19,8 @@ describe('useToast', () => {
   })
 
   test('should add a toast with error type', () => {
-    const { toasts, denied } = useToast()
-    denied('Operation failed')
+    const { toasts, error } = useToast()
+    error('Operation failed')
     
     expect(toasts.value).toHaveLength(1)
     expect(toasts.value[0]).toEqual({
@@ -90,9 +90,9 @@ describe('useToast', () => {
   })
 
   test('should handle multiple toasts with different types', () => {
-    const { toasts, success, denied, info, warning } = useToast()
+    const { toasts, success, error, info, warning } = useToast()
     success('Success message')
-    denied('Error message')
+    error('Error message')
     info('Info message')
     warning('Warning message')
     

--- a/app/composables/useToast.ts
+++ b/app/composables/useToast.ts
@@ -28,7 +28,7 @@ export const useToast = () => {
     addToast(message, 'success')
   }
 
-  const denied = (message: string) => {
+  const error = (message: string) => {
     addToast(message, 'error')
   }
 
@@ -45,7 +45,7 @@ export const useToast = () => {
     addToast,
     removeToast,
     success,
-    denied,
+    error,
     info,
     warning
   }

--- a/app/error.vue
+++ b/app/error.vue
@@ -1,0 +1,80 @@
+<template>
+<NuxtLayout>
+  <div class="h-full flex items-center justify-center px-4 relative">
+    <div class="max-w-2xl w-full my-auto">
+      <div class="bg-gray-50 backdrop-blur-sm rounded-[32px] overflow-hidden shadow-lg mt-10 md:mt-24 lg:mt-32">
+        <div class="p-8">
+          <div class="text-center mb-8">
+            <h1 class="text-8xl font-bold text-gray-900 mb-4">
+              {{ statusCode }}
+            </h1>
+            <div class="text-2xl font-medium text-gray-700">
+              ⚔️ {{ title }} ⚔️
+            </div>
+          </div>
+
+          <div class="bg-gray-50 rounded-lg p-6 mb-8">
+            <p class="text-lg text-gray-700 leading-relaxed">
+              "{{ quote }}"
+              <span class="block text-gray-500 text-sm mt-3 italic">- {{ quoteAuthor }}</span>
+            </p>
+          </div>
+
+          <div class="flex flex-col sm:flex-row items-center justify-center gap-3">
+            <button
+              type="button"
+              class="px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-400"
+              @click="handleRetry"
+            >
+              🔄 Réessayer
+            </button>
+            <NuxtLink
+              to="/"
+              class="bg-gray-800 text-white px-4 py-2 rounded-lg hover:bg-gray-700 transition-colors duration-300"
+              @click="handleClear"
+            >
+              🏰 Retour à Kaamelott
+            </NuxtLink>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</NuxtLayout>
+</template>
+
+<script setup lang="ts">
+import type { NuxtError } from '#app'
+
+const props = defineProps<{
+  error: NuxtError
+}>()
+
+const statusCode = computed(() => props.error?.statusCode || 500)
+const isNotFound = computed(() => statusCode.value === 404)
+
+const title = computed(() =>
+  isNotFound.value ? 'Page Non Trouvée' : 'Une Erreur est Survenue'
+)
+
+// Répliques thématiques Kaamelott selon le type d'erreur.
+const quote = computed(() =>
+  isNotFound.value
+    ? "Excusez-moi ! Est-ce qu'entre deux encouragements pour débiles, il y aurait moyen de rappeler que pour éviter de creuser au flan il suffirait de cartographier les galeries ?"
+    : "C'est pas faux."
+)
+const quoteAuthor = computed(() => (isNotFound.value ? 'Merlin' : 'Perceval'))
+
+useSeoMeta({
+  title: computed(() => composeSeoTitle(title.value)),
+  robots: 'noindex, follow'
+})
+
+const handleClear = () => clearError({ redirect: '/' })
+
+// « Réessayer » : nettoie l'état d'erreur puis recharge la route courante.
+const handleRetry = () => {
+  const path = useRoute().fullPath
+  clearError({ redirect: path })
+}
+</script>


### PR DESCRIPTION
## Résumé

Implémente l'issue **#32** : ajout d'un error boundary global et amélioration de la robustesse UX (toasts, état de chargement).

## Changements

### 🛡️ `app/error.vue` (nouveau)

Page d'erreur globale aux couleurs de Kaamelott, gérant les **404** et **500** (avec répliques thématiques selon le type). Auparavant, les erreurs SSR/route non gérées (ex. les 500 remontées par les routes API, ou une 404 levée pendant un data-fetch) affichaient la page d'erreur **par défaut de Nuxt**.

- Bouton **« Réessayer »** → `clearError({ redirect: routeCourante })`
- Lien **« Retour à Kaamelott »** → `clearError({ redirect: '/' })`
- `robots: noindex` sur la page d'erreur
- Rendu dans `<NuxtLayout>` pour conserver header / footer / fond

### 🔔 Toasts

- **`BaseToast.vue`** : ajout de la classe manquante pour le type `warning` (`bg-yellow-500`). Les toasts `warning` s'affichaient sans style de fond alors que l'icône était déjà gérée.
- **`useToast.ts`** : renommage de la méthode `denied` → `error` (plus explicite). Tous les consommateurs sont mis à jour avec l'alias `error: showErrorToast` pour éviter la collision avec les variables locales `error` des blocs `catch`.
  - Fichiers impactés : `AuthModal.vue`, `UploadForm.vue`, `FileUpload.vue`, `ShareButtons.vue`, `LikeButton.vue`, `useCommentForm.ts`, `useCommentsList.ts`, `useToast.test.ts`.

### ⏳ `useLikesList.ts`

Standardisation sur l'état natif de `useFetch` (`status` / `error`) via des `computed`, au lieu de refs `isLoading`/`error` maintenues manuellement dans les callbacks `onRequest`/`onResponse`/`onResponseError` (fragiles lors des refetch). L'API publique du composable (`isLoading`, `error`, `refresh`) reste inchangée.

## ✅ Validation

- `pnpm run test` → **229 tests OK** (36 fichiers), y compris `useToast.test.ts` mis à jour.
- `pnpm run lint` → OK
- **Build de production + preview** : une page de test levant une 500 rend bien `error.vue` (HTTP 500, `<h1>500</h1>`, « Une Erreur est Survenue », citation Perceval, boutons « Réessayer » / « Retour à Kaamelott », `robots: noindex`). Page de test supprimée avant commit.

## Notes

- Le comportement singleton de `useToast` (issue #21) n'est **pas** modifié ici : c'est un correctif distinct.
- Le renommage `denied` → `error` est un changement d'API interne du composable — aucun consommateur restant ne référence `denied`.

Closes #32

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7jqavCndiRHVB9cJhmVhB)_