### PR TITLE
♿ Accessibilité : GifModal (dialog/focus trap) et GifCard (clavier + alt text)

### DIFF
--- a/app/components/base/AppImage.vue
+++ b/app/components/base/AppImage.vue
@@ -11,7 +11,8 @@
 <img
   v-else-if="error"
   src="/fondKBg.webp"
-  alt="Image"
+  alt=""
+  role="presentation"
   :width="width"
   :height="height"
   :loading="loading"
@@ -21,6 +22,7 @@
   v-else
   :src="src"
   :alt="alt"
+  :role="alt ? undefined : 'presentation'"
   :width="width"
   :height="height"
   :loading="loading"
@@ -56,7 +58,7 @@ const props = withDefaults(defineProps<Props>(), {
   fit: 'cover',
   position: 'center',
   background: 'transparent',
-  alt: 'Image'
+  alt: ''
 })
 
 const { isLoading, error } = useImage({ src: props.src })

--- a/app/components/gifs/GifCard.vue
+++ b/app/components/gifs/GifCard.vue
@@ -1,13 +1,18 @@
 <template>
 <article
   class="group rounded-[32px] transition-colors duration-300 cursor-pointer max-w-[400px]"
+  role="button"
+  tabindex="0"
+  :aria-label="cardLabel"
   :v-posthog-capture="`click_gif_${gif.slug}`"
-  @click="handleClick">
+  @click="handleClick"
+  @keydown.enter.prevent="handleClick"
+  @keydown.space.prevent="handleClick">
   <div class="relative aspect-video rounded-[32px] overflow-hidden">
     <div class="absolute inset-0 overflow-hidden">
       <AppImage
         :src="gif.url"
-        :alt="gif.quote"
+        :alt="imageAlt"
         format="gif"
         class="w-full h-full object-cover transform transition-transform duration-500 ease-out" />
     </div>
@@ -37,6 +42,7 @@
 </template>
 
 <script lang="ts" setup>
+import { computed } from 'vue'
 import type { Gif } from '~~/shared/types'
 import AppImage from '~/components/base/AppImage.vue'
 
@@ -47,6 +53,15 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: 'click', gif: Gif): void
 }>()
+
+const character = computed(() => props.gif.characters?.[0] ?? '')
+
+const imageAlt = computed(() => {
+  const parts = [character.value, props.gif.quote].filter(Boolean)
+  return parts.length ? `GIF Kaamelott — ${parts.join(' : ')}` : 'GIF Kaamelott'
+})
+
+const cardLabel = computed(() => `Voir le GIF ${imageAlt.value}`)
 
 const handleClick = () => {
   emit('click', props.gif)

--- a/app/components/gifs/GifModal.vue
+++ b/app/components/gifs/GifModal.vue
@@ -1,4 +1,11 @@
 <script setup lang="ts">
+import {
+  TransitionRoot,
+  TransitionChild,
+  Dialog,
+  DialogPanel,
+  DialogTitle,
+} from '@headlessui/vue'
 import type { Gif } from '~~/shared/types'
 import ShareButtons from './ShareButtons.vue'
 import AppImage from '~/components/base/AppImage.vue'
@@ -21,92 +28,119 @@ const handleClose = () => {
 </script>
 
 <template>
-<Transition
-  enter-active-class="transition duration-200 ease-out"
-  enter-from-class="transform scale-95 opacity-0"
-  enter-to-class="transform scale-100 opacity-100"
-  leave-active-class="transition duration-150 ease-in"
-  leave-from-class="transform scale-100 opacity-100"
-  leave-to-class="transform scale-95 opacity-0"
->
-  <div
-    v-if="isOpen"
-    class="fixed inset-0 bg-black/20 backdrop-blur-sm flex items-center justify-center p-4 z-50"
-    @click="handleClose"
-  >
-    <div
-      class="bg-white/95 backdrop-blur-sm rounded-lg max-w-2xl w-full overflow-hidden shadow-lg relative"
-      @click.stop
+<TransitionRoot
+  appear
+  :show="isOpen"
+  as="template">
+  <Dialog
+    as="div"
+    class="relative z-50"
+    @close="handleClose">
+    <TransitionChild
+      as="template"
+      enter="transition duration-200 ease-out"
+      enter-from="opacity-0"
+      enter-to="opacity-100"
+      leave="transition duration-150 ease-in"
+      leave-from="opacity-100"
+      leave-to="opacity-0"
     >
-      <AppImage
-        :src="gif.url"
-        :alt="gif.quote"
-        format="gif"
-        class="w-full transform transition-transform duration-500 ease-out"
-      />
-      <div class="absolute top-0 right-0 p-2">
-        <button @click="handleClose">
-          <Icon
-            name="heroicons:x-mark"
-            class="w-6 h-6 text-gray-900 dark:text-gray-200"
-          />
-        </button>
-      </div>
-      <div class="p-4">
-        <div class="flex space-x-2.5 items-center">
-          <p class="text-xl font-medium text-gray-900">{{ gif.quote }}</p>
-          <LikeButton
-            :entity-id="gif.id"
-            :entity-type="Entities.GIF"
-          />
-        </div>
-        <div class="mt-4">
-          <p class="text-sm text-gray-500">Personnages présents :</p>
-          <div class="flex flex-wrap gap-2 mt-2">
-            <NuxtLink
-              v-for="character in gif.characters"
-              :key="character"
-              :to="`/personnages/${slugify(character)}`"
-              class="px-3 py-1 bg-gray-200/80 rounded-full text-sm text-gray-600"
-              :v-posthog-capture="`click_personnage_${character}`"
-              prefetch
-            >
-              {{ character }}
-            </NuxtLink>
-          </div>
-        </div>
-        <div class="mt-4">
-          <p class="text-sm text-gray-500">Personnages qui parlent :</p>
-          <div class="flex flex-wrap gap-2 mt-2">
-            <NuxtLink
-              v-for="character in gif.characters_speaking"
-              :key="character"
-              :to="`/personnages/${slugify(character)}`"
-              class="px-3 py-1 bg-gray-200/80 rounded-full text-sm text-gray-700 border-[0.25px] border-gray-800/50 dark:bg-gray-800 dark:text-gray-200"
-              :v-posthog-capture="`click_personnage_${character}`"
-              prefetch
-            >
-              {{ character }}
-            </NuxtLink>
-          </div>
-        </div>
-        <div class="mt-6 border-t pt-4">
-          <div class="flex items-center justify-between">
-            <ShareButtons
-              :gif-url="gif.url"
-              :quote="gif.quote"
+      <div class="fixed inset-0 bg-black/20 backdrop-blur-sm" />
+    </TransitionChild>
+
+    <div class="fixed inset-0 overflow-y-auto">
+      <div class="flex min-h-full items-center justify-center p-4">
+        <TransitionChild
+          as="template"
+          enter="transition duration-200 ease-out"
+          enter-from="transform scale-95 opacity-0"
+          enter-to="transform scale-100 opacity-100"
+          leave="transition duration-150 ease-in"
+          leave-from="transform scale-100 opacity-100"
+          leave-to="transform scale-95 opacity-0"
+        >
+          <DialogPanel
+            class="bg-white/95 backdrop-blur-sm rounded-lg max-w-2xl w-full overflow-hidden shadow-lg relative"
+          >
+            <AppImage
+              :src="gif.url"
+              :alt="gif.quote"
+              format="gif"
+              class="w-full transform transition-transform duration-500 ease-out"
             />
-            <NuxtLink
-              :to="`/gifs/${gif.slug}`"
-              class="px-3 py-1.5 bg-orange-200/80 rounded-xl text-sm text-orange-700 border-[0.25px] border-orange-800/50 dark:bg-orange-800 dark:text-orange-200"
-              prefetch
-            >
-              Voir plus
-            </NuxtLink>
-          </div>
-        </div>
+            <div class="absolute top-0 right-0 p-2">
+              <button
+                type="button"
+                aria-label="Fermer"
+                @click="handleClose">
+                <Icon
+                  name="heroicons:x-mark"
+                  class="w-6 h-6 text-gray-900 dark:text-gray-200"
+                />
+              </button>
+            </div>
+            <div class="p-4">
+              <div class="flex space-x-2.5 items-center">
+                <DialogTitle
+                  as="p"
+                  class="text-xl font-medium text-gray-900">
+                  {{ gif.quote }}
+                </DialogTitle>
+                <LikeButton
+                  :entity-id="gif.id"
+                  :entity-type="Entities.GIF"
+                />
+              </div>
+              <div class="mt-4">
+                <p class="text-sm text-gray-500">Personnages présents :</p>
+                <div class="flex flex-wrap gap-2 mt-2">
+                  <NuxtLink
+                    v-for="character in gif.characters"
+                    :key="character"
+                    :to="`/personnages/${slugify(character)}`"
+                    class="px-3 py-1 bg-gray-200/80 rounded-full text-sm text-gray-600"
+                    :v-posthog-capture="`click_personnage_${character}`"
+                    prefetch
+                  >
+                    {{ character }}
+                  </NuxtLink>
+                </div>
+              </div>
+              <div class="mt-4">
+                <p class="text-sm text-gray-500">Personnages qui parlent :</p>
+                <div class="flex flex-wrap gap-2 mt-2">
+                  <NuxtLink
+                    v-for="character in gif.characters_speaking"
+                    :key="character"
+                    :to="`/personnages/${slugify(character)}`"
+                    class="px-3 py-1 bg-gray-200/80 rounded-full text-sm text-gray-700 border-[0.25px] border-gray-800/50 dark:bg-gray-800 dark:text-gray-200"
+                    :v-posthog-capture="`click_personnage_${character}`"
+                    prefetch
+                  >
+                    {{ character }}
+                  </NuxtLink>
+                </div>
+              </div>
+              <div class="mt-6 border-t pt-4">
+                <div class="flex items-center justify-between">
+                  <ShareButtons
+                    :gif-url="gif.url"
+                    :quote="gif.quote"
+                  />
+                  <NuxtLink
+                    :to="`/gifs/${gif.slug}`"
+                    class="px-3 py-1.5 bg-orange-200/80 rounded-xl text-sm text-orange-700 border-[0.25px] border-orange-800/50 dark:bg-orange-800 dark:text-orange-200"
+                    prefetch
+                  >
+                    Voir plus
+                  </NuxtLink>
+                </div>
+              </div>
+            </div>
+          </DialogPanel>
+        </TransitionChild>
       </div>
     </div>
-  </div>
-</Transition>
-</template> 
+  </Dialog>
+</TransitionRoot>
+</template>


### PR DESCRIPTION
## Contexte

Corrige les issues #27 et #28 concernant l'accessibilité clavier et lecteurs d'écran.

## Changements

### #27 — GifModal accessible
- Reconstruction de `GifModal.vue` sur les composants `Dialog` / `DialogPanel` / `DialogTitle` de `@headlessui/vue` (déjà utilisé ailleurs dans le projet), ce qui apporte nativement :
  - `role="dialog"` + `aria-modal="true"`
  - piège de focus (focus trap)
  - fermeture au clavier via **Escape**
  - libellé accessible via `DialogTitle` (la réplique)
- `aria-label="Fermer"` ajouté au bouton de fermeture (icône seule).

### #28 — GifCard clavier + alt text
- `GifCard.vue` : la carte cliquable devient focusable et actionnable au clavier (`role="button"`, `tabindex="0"`, gestionnaires `keydown.enter` / `keydown.space`) avec un `aria-label` descriptif.
- L'`alt` de l'image est désormais construit à partir du personnage et de la réplique, avec repli signifiant quand la réplique est vide.
- `AppImage.vue` :
  - l'image de repli d'erreur (`fondKBg.webp`) est traitée comme décorative : `alt=""` + `role="presentation"`.
  - suppression du `alt` générique `"Image"` ; un `alt` vide rend l'image décorative (`role="presentation"`) plutôt que d'exposer un texte non descriptif.

## Notes
Aucun changement d'API des composants (`GifModal` conserve `gif` / `is-open` / `@close`, `GifCard` conserve `gif` / `@click`).

Closes #27
Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014uM7bSM5NUsKs5xn4ShEwt)_